### PR TITLE
Use check-expand-* instead of check-equal? for threading tests

### DIFF
--- a/rackjure/threading.rkt
+++ b/rackjure/threading.rkt
@@ -29,20 +29,20 @@
 (begin-for-syntax 
   (define stx-coerce-to-list
     (syntax-parser
-      [((~literal quote) x) #'((quote x))]
-      ;; ^ We want to end up with ((quote x) y), NOT (quote x y).
-      [(form ...) #'(form ...)]
-      [ form      #'(form)]))
+     [((~literal quote) x) #'((quote x))]
+     ;; ^ We want to end up with ((quote x) y), NOT (quote x y).
+     [(form ...) #'(form ...)]
+     [ form      #'(form)]))
 
   (define ((keep-stxctx f) stx . args)
     (datum->syntax stx (syntax-e (apply f stx args))))
 
   (define (threading-syntax-parser threader)
     (syntax-parser
-      [(_ first rest ...)
-       (define normalized-rest (stx-map (keep-stxctx stx-coerce-to-list)
-                                        #'(rest ...)))
-       (foldl (keep-stxctx threader) #'first normalized-rest)])))
+     [(_ first rest ...)
+      (define normalized-rest (stx-map (keep-stxctx stx-coerce-to-list)
+                                       #'(rest ...)))
+      (foldl (keep-stxctx threader) #'first normalized-rest)])))
 
 (module+ test
   (define-syntax test-threader


### PR DESCRIPTION
I opted out of using one `module+` block per macro because it got too crowded IMHO.

Let me know if you think I overdid it with `test-threader`. (I wanted to test arity 1 only once and figured it would be right to do it on something else than the real threading macros. OTOH, `threading-syntax-parser` is an implementation detail which begs the question of white vs. black box testing.)

*sigh* Testing is hard.
