### PR TITLE
add keyword arguments to reader function literals

### DIFF
--- a/rackjure/lambda-reader.rkt
+++ b/rackjure/lambda-reader.rkt
@@ -4,7 +4,9 @@
          racket/match
          (only-in racket/port input-port-append)
          (only-in racket/list filter-map remove-duplicates append*)
-         rackjure/threading)
+         rackjure/threading
+         (for-syntax racket/base)
+         )
 
 (provide wrapper1
          lambda-readtable)


### PR DESCRIPTION
add keyword arguments to reader function literals and also allow an arbitrary number of arguments, and also handle skipped arguments, and both % and %1.  
Examples:

```
#lang rackjure
(map #λ(+ % 1) '(1 2 3))                   ;=> '(2 3 4)
(map #λ(+ % %2) '(1 2 3) '(1 2 3))         ;=> '(2 4 6)
(#λ(apply list* % %&) 1 '(2 3))            ;=> '(1 2 3)
(#λ(* 1/2 %#:m (* %#:v %#:v)) #:m 2 #:v 1) ;=> 1        ; keyword-arguments
(define x (#λ"I am x"))
(#λx)                                      ;=> "I am x" ;the body doesn't have to be in parens
(#λ(begin (set! % "%") %1) "%1")           ;=> "%"      ;% means exactly the same as %1,
                                                        ;and you can even use both at the same time,
                                                        ;and even set!-ing one set!s the other.
(#λ%2 "ignored" "%2")                      ;=> "%2"     ;handles skipped arguments
(apply #λ%42 (build-list 42 add1))         ;=> 42       ;handles an arbitrary number of arguments
```
