### PR TITLE
include ~>% ~>_ and ~>f

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 compiled/
 htmldocs/
+*~

--- a/rackjure/check-expansion.rkt
+++ b/rackjure/check-expansion.rkt
@@ -5,7 +5,8 @@
          rackunit)
 
 (provide check-expand-once
-         check-expand-fully)
+         check-expand-fully
+         check-equal?)
 
 ;; 1. These are macros not functions so that check failure source
 ;; location will be correct. Also, note we need to use quasisyntax/loc

--- a/rackjure/lambda-reader.rkt
+++ b/rackjure/lambda-reader.rkt
@@ -13,9 +13,11 @@
   (with-syntax ([args (parse-args stx)]
                 [%1 (datum->syntax stx '%1 stx)]
                 [body stx])
-    #'(lambda args
-        (define-syntax % (make-rename-transformer #'%1))
-        body)))
+    (syntax-property
+     #'(lambda args
+         (define-syntax % (make-rename-transformer #'%1))
+         body)
+     'afl #t)))
 
 (module+ test
   (require rackunit)

--- a/rackjure/rackjure.scrbl
+++ b/rackjure/rackjure.scrbl
@@ -16,6 +16,10 @@
                   [sandbox-error-output 'string])
      (make-evaluator 'rackjure)))
 
+@;; example: @racket[(map @#,afl[(+ % 1)] '(1 2 3))]
+@(define-syntax-rule @afl[form ...]
+   @elem{@tt{#λ}@racket[form ...]})
+
 @title{#lang rackjure}
 
 Provide a few Clojure-inspired ideas in Racket. Where Racket and
@@ -228,6 +232,7 @@ but it doesn't insert the expression into the form, it simply applies the proc
 to the expression.
 @racketblock[
 (~>f #"foobar" bytes-length (λ (n) (number->string n 16)) string->bytes/utf-8)
+(~>f #"foobar" bytes-length @#,afl[(number->string % 16)] string->bytes/utf-8)
 (apply ~>f #"foobar" (list bytes-length (λ (n) (number->string n 16)) string->bytes/utf-8))
 ]}
 
@@ -714,24 +719,24 @@ Therefore Rackjure instead uses your choice of @litchar{#fn( )},
 Examples:
 
 @verbatim{
-> (map #λ(+ % 1) '(1 2 3))
-'(2 3 4)
-> (map #λ(+ % %2) '(1 2 3) '(1 2 3))
-'(2 4 6)
+> @racket[(map @#,afl[(+ % 1)] '(1 2 3))]
+@racketresult['(2 3 4)]
+> @racket[(map @#,afl[(+ % %2)] '(1 2 3) '(1 2 3))]
+@racketresult['(2 4 6)]
 
-;; Rest argument
-> (#λ(apply list* % %&) 1 '(2 3))
-'(1 2 3)
+@racketcommentfont{;; Rest argument}
+> @racket[(@#,afl[(apply list* % %&)] 1 '(2 3))]
+@racketresult['(1 2 3)]
 
-;; Keyword argument
-> (#λ(* 1/2 %#:m (* %#:v %#:v)) #:m 2 #:v 1)
-1
+@racketcommentfont{;; Keyword argument}
+> @racket[(@#,afl[(* 1/2 %#:m (* %#:v %#:v))] #:m 2 #:v 1)]
+@racketresult[1]
 
-;; Ignores unused arguments
-> (#λ(begin %2) "ignored" "used")
-"used"
+@racketcommentfont{;; Ignores unused arguments}
+> @racket[(@#,afl[(begin %2)] "ignored" "used")]
+@racketresult["used"]
 
-;; Handles an arbitary number of arguments
-> (apply #λ(list %1 %42) (build-list 42 add1))
-(list 1 42)
+@racketcommentfont{;; Handles an arbitary number of arguments}
+> @racket[(apply @#,afl[(list %1 %42)] (build-list 42 add1))]
+@racketresult['(1 42)]
 }

--- a/rackjure/rackjure.scrbl
+++ b/rackjure/rackjure.scrbl
@@ -7,7 +7,7 @@
                      rackjure/dict
                      rackjure/egal
                      rackjure/str
-                     rackjure/threading
+                     (except-in rackjure/threading %)
                      rackjure/utils
                      racket))
 
@@ -180,6 +180,60 @@ Analogous to @tt{some->} in Clojure, i.e. stop threading at a
 Analogous to @tt{some->>} in Clojure, i.e. stop threading at a
 @racket[#f] value.
 
+}
+
+@defform[(~>% expression form ...)]{
+
+Like @racket[~>], except that instead of always inserting the expression
+as the second item of each form, it insertes it every place where there
+is a @racket[%] placeholder.  
+
+If there is no @racket[%] in the form, it simply treats the form as if it were
+@racket[(form %)].
+
+It also cooperates with @secref["func-lit"] so that the expression doesn't
+get inserted in a @racket[%] that's being used as an argument.
+
+@racketblock[
+(~>% #"foobar" bytes-length (number->string % 16) string->bytes/utf-8)
+]
+
+based on the
+@hyperlink["https://github.com/rplevy/swiss-arrows#a-generalization-of-the-arrow"]{"diamond wand" from rplevy/swiss-arrows}.
+}
+
+@defform[(~>_ expression form ...)]{
+
+Like @racket[~>%], except that it uses @racket[_] as a placeholder instead of
+@racket[%].  
+
+@racketblock[
+(~>_ #"foobar" bytes-length (number->string _ 16) string->bytes/utf-8)
+]}
+
+@defform[(some~>% expression form ...)]{
+Like @racket[~>%], except that it stops threading at a @racket[#f] value like
+@racket[some~>] would.
+}
+
+@defform[(some~>_ expression form ...)]{
+Like @racket[~>_], except that it stops threading at a @racket[#f] value like
+@racket[some~>] would.
+}
+
+@defproc[(~>f [expression any/c] [proc procedure?] ...) any/c]{
+Like @racket[~>], except that it can be used a function.  
+It still works as a macro if you use @racket[(~>f expression proc ...)],
+but it doesn't insert the expression into the form, it simply applies the proc
+to the expression.
+@racketblock[
+(~>f #"foobar" bytes-length (λ (n) (number->string n 16)) string->bytes/utf-8)
+(apply ~>f #"foobar" (list bytes-length (λ (n) (number->string n 16)) string->bytes/utf-8))
+]}
+
+@defproc[(some~>f [expression any/c] [proc procedure?] ...) any/c]{
+Like @racket[~>f], except that it stops threading at a @racket[#f] value like
+@racket[some~>] would.
 }
 
 @;--------------------------------------------------------------------

--- a/rackjure/threading.rkt
+++ b/rackjure/threading.rkt
@@ -2,13 +2,21 @@
 
 (require (for-syntax racket/base
                      syntax/parse
-                     syntax/stx)
-         (only-in "conditionals.rkt" if-let))
+                     syntax/stx
+                     racket/local)
+         (only-in "conditionals.rkt" if-let)
+         racket/local)
 
 (provide ~>
          ~>>
+         ~>%
+         ~>_
          some~>
-         some~>>)
+         some~>>
+         some~>%
+         some~>_
+         %
+         )
 
 (module+ test
   (require "check-expansion.rkt")
@@ -30,6 +38,8 @@
 ;;
 ;; Also rewritten to use a fold instead of recursive invocations to
 ;; avoid the issues described in CLJ-1121.
+;;
+;; Also including some forms based on git://github.com/rplevy/swiss-arrows
 
 (begin-for-syntax 
   (define stx-coerce-to-list
@@ -40,7 +50,7 @@
      [ form      #'(form)]))
 
   (define ((keep-stxctx f) stx . args)
-    (datum->syntax stx (syntax-e (apply f stx args))))
+    (datum->syntax stx (syntax-e (apply f stx args)) stx stx))
 
   (define (threading-syntax-parser threader)
     (syntax-parser
@@ -77,6 +87,123 @@
    (lambda (form nested-form)
      #`(if-let [tmp #,nested-form] (~>> tmp #,form) #f))))
 
+(define-syntax %
+  (lambda (stx)
+    (raise-syntax-error #f "must be used in either a #λ, #fn, #lambda, or ~>% form" stx)))
+
+(begin-for-syntax
+  (define (insertion-threading-syntax-parser placeholder?)
+    (local [(define (threader form nested-form)
+              (define inc (includes-placeholder? form nested-form))
+              (cond [inc inc]
+                    [else #`(#,form #,nested-form)]))
+            (define (includes-placeholder? form nested-form)
+              (syntax-parse form
+                [form:id (cond [(placeholder? #'form) nested-form]
+                               [else #f])]
+                [form #:when (syntax-property #'form 'afl) #f]
+                [() #f]
+                [(sub-fst . sub-rst)
+                 (let ([sub-fst-inc (includes-placeholder? #'sub-fst nested-form)]
+                       [sub-rst-inc (includes-placeholder? #'sub-rst nested-form)])
+                   (cond [(and sub-fst-inc sub-rst-inc) #`(#,sub-fst-inc . #,sub-rst-inc)]
+                         [sub-fst-inc #`(#,sub-fst-inc . sub-rst)]
+                         [sub-rst-inc #`(sub-fst . #,sub-rst-inc)]
+                         [else #f]))]
+                [#(sub ...)
+                 (let ([lst-inc (includes-placeholder? #'(sub ...) nested-form)])
+                   (cond [lst-inc (syntax->datum form (list->vector (syntax->list lst-inc)) form form)]
+                         [else #f]))]
+                [_ #f]))
+            (define (threading-syntax-parser threader)
+              (syntax-parser
+                [(_ first rest ...)
+                 (define normalized-rest (syntax->list #'(rest ...)))
+                 (foldl (keep-stxctx threader) #'first normalized-rest)]))]
+      (threading-syntax-parser threader)))
+  )
+
+(define-syntax ~>%
+  (insertion-threading-syntax-parser
+   (lambda (stx)
+     (syntax-parse stx
+       [(~literal %) #t]
+       [_ #f]))))
+
+(define-syntax ~>_
+  (insertion-threading-syntax-parser
+   (lambda (stx)
+     (syntax-parse stx
+       [(~literal _) #t]
+       [_ #f]))))
+
+(define-syntax some~>%
+  (threading-syntax-parser
+   (lambda (form nested-form)
+     #`(if-let [tmp #,nested-form] (~>% tmp #,form) #f))))
+
+(define-syntax some~>_
+  (threading-syntax-parser
+   (lambda (form nested-form)
+     #`(if-let [tmp #,nested-form] (~>_ tmp #,form) #f))))
+
+(define-syntax ~>f
+  (local [(define (threader form nested-form)
+            #`(#,form #,nested-form))
+          (define (threading-syntax-parser threader)
+            (syntax-parser
+              [(_ first rest ...)
+               (define normalized-rest (syntax->list #'(rest ...)))
+               (foldl (keep-stxctx threader) #'first normalized-rest)]))
+          (define parse (threading-syntax-parser threader))]
+    (lambda (stx)
+      (syntax-parse stx
+        [(_ . stuff) (parse stx)]
+        [_:id #'~>f-function]
+        ))))
+
+(define ~>f-function
+  (local [(define (~>f expr . fs)
+            (~>f--lst expr fs))
+          (define (~>f--lst expr fs)
+            (cond [(empty? fs) expr]
+                  [else (define f (first fs))
+                        (~>f--lst (f expr) (rest fs))]))
+          (define empty? null?)
+          (define first car)
+          (define rest cdr)]
+    ~>f))
+
+(define-syntax some~>f
+  (local [(define (threader form nested-form)
+            #`(if-let [tmp #,nested-form] (#,form tmp) #f))
+          (define (threading-syntax-parser threader)
+            (syntax-parser
+              [(_ first rest ...)
+               (define normalized-rest (syntax->list #'(rest ...)))
+               (foldl (keep-stxctx threader) #'first normalized-rest)]))
+          (define parse (threading-syntax-parser threader))]
+    (lambda (stx)
+      (syntax-parse stx
+        [(_ . stuff) (parse stx)]
+        [_:id #'some~>f-function]
+        ))))
+
+(define some~>f-function
+  (local [(define (some~>f expr . fs)
+            (some~>f--lst expr fs))
+          (define (some~>f--lst expr fs)
+            (cond [(empty? fs) expr]
+                  [(false? expr) #f]
+                  [else (define f (first fs))
+                        (some~>f--lst (f expr) (rest fs))]))
+          (define empty? null?)
+          (define first car)
+          (define rest cdr)
+          (define false? not)]
+    some~>f))
+
+
 (module+ test
   (check-expand-once anchor #'(~> 1 (f 2))     #'(f 1 2))
   (check-expand-once anchor #'(~> #t (if 1 2)) #'(if #t 1 2))
@@ -92,7 +219,34 @@
   
   (check-expand-once anchor
                      #'(some~>> 1 f)
-                     #'(if-let [tmp 1](~>> tmp (f)) #f)))
+                     #'(if-let [tmp 1](~>> tmp (f)) #f))
+  
+  (check-expand-once anchor #'(~>_ 1 (f _ 2))     #'(f 1 2))
+  (check-expand-once anchor #'(~>_ #t (if _ 1 2)) #'(if #t 1 2))
+  (check-expand-once anchor #'(~>_ 1 (f 2 _))     #'(f 2 1))
+  (check-expand-fully anchor #'(~>_ 1 + (~>> 1 + _)) #'(#%app + '1 (#%app + '1)))
+  (check-expand-once anchor #'(~>_ 1 _) #'1)
+  (check-expand-once anchor
+                     #'(~>_ #"foobar" bytes-length (number->string _ 16) string->bytes/utf-8)
+                     #'(string->bytes/utf-8 (number->string (bytes-length #"foobar") 16)))
+  (check-expand-once anchor
+                     #`(~>% #"foobar"
+                            bytes-length
+                            #,(syntax-property #'(λ (%) (number->string % 16)) 'afl #t)
+                            string->bytes/utf-8)
+                     #'(string->bytes/utf-8 ((λ (%) (number->string % 16)) (bytes-length #"foobar"))))
+  (check-expand-once anchor
+                     #'(~>f #"foobar"
+                            bytes-length
+                            (λ (%) (number->string % 16))
+                            string->bytes/utf-8)
+                     #'(string->bytes/utf-8 ((λ (%) (number->string % 16)) (bytes-length #"foobar"))))
+  (check-equal? (apply ~>f #"foobar"
+                       (list bytes-length
+                             (λ (%) (number->string % 16))
+                             string->bytes/utf-8))
+                (string->bytes/utf-8 ((λ (%) (number->string % 16)) (bytes-length #"foobar"))))
+  )
 
 ;; Confirm expansion using default #%app
 (module+ test


### PR DESCRIPTION
```racket
#lang rackjure
(~>% #"foobar" bytes-length (number->string % 16) string->bytes/utf-8)
(~>_ #"foobar" bytes-length (number->string _ 16) string->bytes/utf-8)
```