### PR TITLE
Move the procedure? test to #%app

### DIFF
--- a/rackjure/check-expansion.rkt
+++ b/rackjure/check-expansion.rkt
@@ -5,7 +5,9 @@
          rackunit)
 
 (provide check-expand-once
-         check-expand-fully)
+         check-expand-fully
+         check-expand-once/both
+         check-expand-fully/both)
 
 ;; 1. These are macros not functions so that check failure source
 ;; location will be correct. Also, note we need to use quasisyntax/loc
@@ -23,14 +25,21 @@
 
 (define-syntax (check-expansion stx)
   (syntax-parse stx
-    [(_ expander:id anchor:anchor input:expr expected:expr)
+    [(_ expander-input:id expander-expected:id anchor:anchor input:expr expected:expr)
      #`(parameterize ([current-namespace (namespace-anchor->namespace anchor)])
          #,(quasisyntax/loc stx
-             (check-equal? (syntax->datum (expander input))
-                           (syntax->datum expected))))]))
+             (check-equal? (syntax->datum (expander-input input))
+                           (syntax->datum (expander-expected expected)))))]))
 
 (define-syntax-rule (check-expand-once anchor input expected)
-  (check-expansion expand-once anchor input expected))
+  (check-expansion expand-once values anchor input expected))
 
 (define-syntax-rule (check-expand-fully anchor input expected)
-  (check-expansion expand anchor input expected))
+  (check-expansion expand values anchor input expected))
+
+(define-syntax-rule (check-expand-once/both anchor input expected)
+  (check-expansion expand-once expand-once anchor input expected))
+
+(define-syntax-rule (check-expand-fully/both anchor input expected)
+  (check-expansion expand expand anchor input expected))
+

--- a/rackjure/threading.rkt
+++ b/rackjure/threading.rkt
@@ -119,21 +119,11 @@
     (require "check-expansion.rkt")
     (define-namespace-anchor anchor)
     ;; 1. Directly; expanding ~> macro
-    (check-expand-fully anchor
-                        #'(~> 1 +)
-                        #'(let-values ([(x_) +] [(y_) (quote 1)])
-                            (if (#%app procedure? x_)
-                                (let-values () (#%app x_ y_))
-                                (let-values () (#%app maybe-dict-ref x_ y_)))))
+    (check-expand-fully/both anchor
+                             #'(~> 1 +)
+                             #'(#%app + (quote 1)))
     ;; 2. Indirectly; no implicit require of wrong #%app
-    (check-expand-fully anchor
-                        #'((hasheq 'a 42) 'a)
-                        #'(let-values ([(x_) (let-values ([(x_) hasheq] [(y_) (quote a)] [(z_) (quote 42)])
-                                               (if (#%app procedure? x_)
-                                                   (let-values () (#%app x_ y_ z_))
-                                                   (let-values () (#%app maybe-dict-set x_ y_ z_))))]
-                                       [(y_) (quote a)])
-                            (if (#%app procedure? x_)
-                                (let-values () (#%app x_ y_))
-                                (let-values () (#%app maybe-dict-ref x_ y_))))))
+    (check-expand-fully/both anchor
+                             #'((hasheq 'a 42) 'a)
+                             #'(#%app (#%app hasheq (quote a) (quote 42)) (quote a))))
   (require 'test-dict-app))


### PR DESCRIPTION
The Racket compiler can optimize at compile time some expressions like
`(procedure? f)` when `f` is never `set!`ed. So in the normal case the test
disappears. This also enables other optimizations like constant folding.

The problem is that some tests become too verbose and it leaks too many implementation details. The second commit is a try to fix this.

This example shows the improvements in the running time:

    #lang racket/base ;s-exp "rackjure/rackjure/main.rkt"
    (require "rackjure/rackjure/app.rkt")
    (require "rackjure/rackjure/app-old.rkt")

    (time (for/last ([i (in-range 10000000)])
            (-#%app/old + 2 (random 1))))
    (time (for/last ([i (in-range 10000000)])
            (-#%app + 2 (random 1))))
    ;cpu time: 12948 real time: 13712 gc time: 0
    ;cpu time: 10062 real time: 10791 gc time: 0

    (time (for/last ([i (in-range 10000000)])
            (-#%app/old + 2 3)))
    (time (for/last ([i (in-range 10000000)])
            (-#%app + 2 3)))
    ;cpu time: 2200 real time: 2327 gc time: 0
    ;cpu time: 62 real time: 63 gc time: 0
