### PR TITLE
Make threading tests compatible with the Racket 7 expander

### DIFF
--- a/rackjure/threading.rkt
+++ b/rackjure/threading.rkt
@@ -23,11 +23,11 @@
   (require "check-expansion.rkt")
   (define-namespace-anchor anchor)
 
-  (check-expand-fully anchor #'(~> 1 (f 2))     #'(#%app f (quote 1) (quote 2)))
+  (check-expand-fully anchor #'(~> 1 (+ 2))     #'(#%app + (quote 1) (quote 2)))
   (check-expand-fully anchor #'(~> #t (if 1 2)) #'(if (quote #t) (quote 1) (quote 2)))
   ;; ^ Check that it works with syntax forms
 
-  (check-expand-fully anchor #'(~>> 1 (f 2))       #'(#%app f (quote 2) (quote 1)))
+  (check-expand-fully anchor #'(~>> 1 (+ 2))       #'(#%app + (quote 2) (quote 1)))
   (check-expand-fully anchor #'(~>> 1 + (~>> 1 +)) #'(#%app + '1 (#%app + '1)))
   ;; ^ Example from CLJ-1121
 


### PR DESCRIPTION
This updates the test suite for `rackjure/threading` to work on the Racket 7 expander (and maintain compatibility with older versions as well). See racket/racket#2099 for more details.